### PR TITLE
Elemental Spell Damage and Spell Sort Terms

### DIFF
--- a/durian/terms/mod-ofs.txt
+++ b/durian/terms/mod-ofs.txt
@@ -18,6 +18,22 @@ lightdmg|ldmg                       =       mod_name=#% increased Lightning Dama
 (\d+)(lightdmg|ldmg)                =       mod_name=#% increased Lightning Damage&mod_min=$GROUP1&mod_max=&$MG
 (\d+)-(\d+)(lightdmg|ldmg)          =       mod_name=#% increased Lightning Damage&mod_min=$GROUP1&mod_max=$GROUP2&$MG
 
+coldspelldmg|csdmg                  =       mod_name=(pseudo) (total) #% increased Cold Spell Damage&mod_min=&mod_max=&$MG
+(\d+)(coldspelldmg|csdmg)           =       mod_name=(pseudo) (total) #% increased Cold Spell Damage&mod_min=$GROUP1&mod_max=&$MG
+(\d+)-(\d+)(coldspelldmg|csdmg)     =       mod_name=(pseudo) (total) #% increased Cold Spell Damage&mod_min=$GROUP1&mod_max=$GROUP2&$MG
+
+firespelldmg|fsdmg                  =       mod_name=(pseudo) (total) #% increased Fire Spell Damage&mod_min=&mod_max=&$MG
+(\d+)(firespelldmg|fsdmg)           =       mod_name=(pseudo) (total) #% increased Fire Spell Damage&mod_min=$GROUP1&mod_max=&$MG
+(\d+)-(\d+)(firespelldmg|fsdmg)     =       mod_name=(pseudo) (total) #% increased Fire Spell Damage&mod_min=$GROUP1&mod_max=$GROUP2&$MG
+
+
+lightspelldmg|lsdmg                 =       mod_name=(pseudo) (total) #% increased Lightning Spell Damage&mod_min=&mod_max=&$MG
+
+(\d+)(lightspelldmg|lsdmg)          =       mod_name=(pseudo) (total) #% increased Lightning Spell Damage&mod_min=$GROUP1&mod_max=&$MG
+
+(\d+)-(\d+)(lightspelldmg|lsdmg)    =       mod_name=(pseudo) (total) #% increased Lightning Spell Damage&mod_min=$GROUP1&mod_max=$GROUP2&$MG
+
+
 manaregen|mregen                    =       mod_name=(pseudo) (total) #% increased Mana Regeneration Rate&mod_min=&mod_max=&$MG
 (\d+)(manaregen|mregen)             =       mod_name=(pseudo) (total) #% increased Mana Regeneration Rate&mod_min=$GROUP1&mod_max=&$MG
 (\d+)-(\d+)(manaregen|mregen)       =       mod_name=(pseudo) (total) #% increased Mana Regeneration Rate&mod_min=$GROUP1&mod_max=$GROUP2&$MG

--- a/durian/terms/mod-ofs.txt
+++ b/durian/terms/mod-ofs.txt
@@ -26,13 +26,9 @@ firespelldmg|fsdmg                  =       mod_name=(pseudo) (total) #% increas
 (\d+)(firespelldmg|fsdmg)           =       mod_name=(pseudo) (total) #% increased Fire Spell Damage&mod_min=$GROUP1&mod_max=&$MG
 (\d+)-(\d+)(firespelldmg|fsdmg)     =       mod_name=(pseudo) (total) #% increased Fire Spell Damage&mod_min=$GROUP1&mod_max=$GROUP2&$MG
 
-
 lightspelldmg|lsdmg                 =       mod_name=(pseudo) (total) #% increased Lightning Spell Damage&mod_min=&mod_max=&$MG
-
 (\d+)(lightspelldmg|lsdmg)          =       mod_name=(pseudo) (total) #% increased Lightning Spell Damage&mod_min=$GROUP1&mod_max=&$MG
-
 (\d+)-(\d+)(lightspelldmg|lsdmg)    =       mod_name=(pseudo) (total) #% increased Lightning Spell Damage&mod_min=$GROUP1&mod_max=$GROUP2&$MG
-
 
 manaregen|mregen                    =       mod_name=(pseudo) (total) #% increased Mana Regeneration Rate&mod_min=&mod_max=&$MG
 (\d+)(manaregen|mregen)             =       mod_name=(pseudo) (total) #% increased Mana Regeneration Rate&mod_min=$GROUP1&mod_max=&$MG

--- a/durian/terms/sort.txt
+++ b/durian/terms/sort.txt
@@ -25,5 +25,5 @@ sortcrit            =       crit
 sortlvl             =       level
 sortmapq            =       mapq
 
-; This is used as sorting key for explicit mod groups, e.g. 'bowchaostrap' 
+; This is used as sorting key for explicit mod groups, e.g. 'bowchaostrap'
 sortgrp0        =       #|0

--- a/durian/terms/sort.txt
+++ b/durian/terms/sort.txt
@@ -2,28 +2,32 @@
 ; Sort, note that this is a special case since this is not actually part of the normal POST payload
 ; Note that all sort keywords should start by 'sort'
 ;
-sortprice           =       price_in_chaos
-sortlife            =       #(pseudo) (total) +# to maximum Life
-sortcoldres         =       #(pseudo) (total) +#% to Cold Resistance
-sortfireres         =       #(pseudo) (total) +#% to Fire Resistance
-sortlight(ning)?res =       #(pseudo) (total) +#% to Lightning Resistance
-sortdex             =       #(pseudo) (total) +# to Dexterity
-sortstr             =       #(pseudo) (total) +# to Strength
-sortint             =       #(pseudo) (total) +# to Intelligence
+sortprice                               =       price_in_chaos
+sortlife                                =       #(pseudo) (total) +# to maximum Life
+sortcoldres                             =       #(pseudo) (total) +#% to Cold Resistance
+sortfireres                             =       #(pseudo) (total) +#% to Fire Resistance
+sortlight(ning)?res                     =       #(pseudo) (total) +#% to Lightning Resistance
+sortdex                                 =       #(pseudo) (total) +# to Dexterity
+sortstr                                 =       #(pseudo) (total) +# to Strength
+sortint                                 =       #(pseudo) (total) +# to Intelligence
+sortsdmg|sortspelldmg                   =       #(pseudo) (total) #% increased Spell Damage
+sortcsdmg|sortcoldspelldmg			        =	      #(pseudo) (total) #% increased Cold Spell Damage
+sortfsdmg|sortfirespelldmg			        =	      #(pseudo) (total) #% increased Fire Spell Damage
+sortlsdmg|sortlightspelldmg			        =	      #(pseudo) (total) #% increased Lightning Spell Damage
 
-sortq               =       q
-sortpd              =       quality_pd
-sorted              =       ed
-sortaps             =       aps
-sortpdps            =       quality_pdps
-sortedps            =       edps
-sortar              =       quality_armour
-sortev              =       quality_evasion
-sortes              =       quality_shield
-sortbl(oc)?k        =       block
-sortcrit            =       crit
-sortlvl             =       level
-sortmapq            =       mapq
+sortq                                   =       q
+sortpd                                  =       quality_pd
+sorted                                  =       ed
+sortaps                                 =       aps
+sortpdps                                =       quality_pdps
+sortedps                                =       edps
+sortar                                  =       quality_armour
+sortev                                  =       quality_evasion
+sortes                                  =       quality_shield
+sortbl(oc)?k                            =       block
+sortcrit                                =       crit
+sortlvl                                 =       level
+sortmapq                                =       mapq
 
 ; This is used as sorting key for explicit mod groups, e.g. 'bowchaostrap'
 sortgrp0        =       #|0


### PR DESCRIPTION
Added terms for getting (pseudo) (total) #% increased Fire Spell Damage, etc
Added sort terms for spell damage and the elemental spell damages
I'm on Windows and my spacing is a little weird :/
If I need to fix the spacing I'll redo it on a Unix box.
