### PR TITLE
Added early Bailout

### DIFF
--- a/durian/script/fm.js
+++ b/durian/script/fm.js
@@ -75,6 +75,9 @@ function affixMaxLookUp(baseType, modName) {
 		// print(baseTypeFlag + ':' + modName + ' = ' + affix.mod)
 		if(baseTypeFlag && baseTypeFlag.indexOf('Yes') != -1 && affix.mod == modName) {			
 			if(maxTier < affix.tier) maxTier = affix.tier;
+		}else{
+			if(maxTier > 0)
+				return maxTier;
 		}
 	}
 	return maxTier;


### PR DESCRIPTION
apparently the last time i added that i added it to the normal affix lookup instead of the maxaffixLookup, still relies on the assumptions that the affix file is sorted
